### PR TITLE
Remove /api prefix from middleware

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig(() => ({
       "./server/index"
     );
     const expressApp = createExpressServer();
-    server.middlewares.use("/api", expressApp);
+    server.middlewares.use(expressApp);
   },
   resolve: {
     alias: {


### PR DESCRIPTION
### Description

This pull request removes the `/api` prefix from the middleware in `vite.config.ts`.

### Changes

- In `vite.config.ts`, the `expressApp` middleware is now mounted at the root of the server instead of under the `/api` path.

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 10`

🔗 [Edit in Builder.io](https://builder.io/app/projects/32a72d29da3546e5b0cab9b8fb707376/glow-realm)

👀 [Preview Link](https://32a72d29da3546e5b0cab9b8fb707376-glow-realm.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>32a72d29da3546e5b0cab9b8fb707376</projectId>-->
<!--<branchName>glow-realm</branchName>-->